### PR TITLE
Hotfix for menu play button and level 1 button in level select

### DIFF
--- a/Menu/Scripts/Level_select.gd
+++ b/Menu/Scripts/Level_select.gd
@@ -6,14 +6,11 @@ func _ready():
 	pass # Replace with function body.
 
 
-
-
-
 func _on_back_pressed():
 	get_tree().change_scene_to_file("res://Menu/Scenes/Main_menu.tscn")
 	print("Loading Menu")
 
 
 func _on_level_1_pressed():
-	get_tree().change_scene_to_file("res://Levels/Scene_1.tscn")
-	print("Loading Scene_1.tscn")
+	get_tree().change_scene_to_file("res://Levels/test_level.tscn")
+	print("Loading test_level.tscn")

--- a/Menu/Scripts/menu.gd
+++ b/Menu/Scripts/menu.gd
@@ -3,8 +3,8 @@ extends Node
 
 #used to call 
 func _on_play_pressed():
-	get_tree().change_scene_to_file("res://Levels/Scene_1.tscn")
-	print("Loading Scene_1.tscn")
+	get_tree().change_scene_to_file("res://Levels/test_level.tscn")
+	print("Loading test_level.tscn")
 
 func _on_options_pressed():
 	get_tree().change_scene_to_file("res://Menu/Scenes/Options_menu.tscn")


### PR DESCRIPTION
Hotfix to set up the play button and level select for level 1 to point to the current test level. 

# How to test
- Launch game and press play
  - Test level should open
- Launch game and press level select
  - Select "Level 1" and it should open 