### PR TITLE
Fixed pause menu draw layer. Refactored main menu and added background.

### DIFF
--- a/Menu/Scenes/Main_menu.tscn
+++ b/Menu/Scenes/Main_menu.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://bg8u8vep831qn"]
+[gd_scene load_steps=3 format=3 uid="uid://bg8u8vep831qn"]
 
 [ext_resource type="Script" path="res://Menu/Scripts/menu.gd" id="1_tkqxq"]
+[ext_resource type="Texture2D" uid="uid://030c3qm04aku" path="res://Assets/splash.png" id="2_shi0o"]
 
 [node name="Menu" type="Control"]
 layout_mode = 3
@@ -11,11 +12,18 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_tkqxq")
 
+[node name="TextureRect" type="TextureRect" parent="."]
+layout_mode = 0
+offset_right = 1975.0
+offset_bottom = 1111.0
+scale = Vector2(0.585, 0.585)
+texture = ExtResource("2_shi0o")
+
 [node name="ColorRect" type="ColorRect" parent="."]
 layout_mode = 0
 offset_right = 1157.0
 offset_bottom = 653.0
-color = Color(0.0196078, 0.027451, 0.156863, 1)
+color = Color(0.0196078, 0.027451, 0.156863, 0.768627)
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 0
@@ -40,6 +48,8 @@ text = "Level Select"
 layout_mode = 2
 text = "Quit"
 
+[connection signal="gui_input" from="VBoxContainer" to="." method="_on_v_box_container_gui_input"]
+[connection signal="button_up" from="VBoxContainer/Play" to="." method="_on_play_button_up"]
 [connection signal="pressed" from="VBoxContainer/Play" to="." method="_on_play_pressed"]
 [connection signal="pressed" from="VBoxContainer/Options" to="." method="_on_options_pressed"]
 [connection signal="pressed" from="VBoxContainer/Level Select" to="." method="_on_level_select_pressed"]

--- a/Menu/Scenes/pausemenu.tscn
+++ b/Menu/Scenes/pausemenu.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" path="res://Menu/Scripts/pause_menu.gd" id="1_vq1at"]
 
 [node name="pausemenu" type="Control"]
+z_index = 5
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -12,6 +13,7 @@ grow_vertical = 2
 script = ExtResource("1_vq1at")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
+z_index = 1
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -30,6 +32,10 @@ layout_mode = 2
 text = "Paused"
 horizontal_alignment = 1
 
+[node name="Resume" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Resume"
+
 [node name="Options" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 text = "Options"
@@ -42,11 +48,7 @@ text = "Home"
 layout_mode = 2
 text = "Quit"
 
-[node name="Resume" type="Button" parent="VBoxContainer"]
-layout_mode = 2
-text = "Resume"
-
+[connection signal="pressed" from="VBoxContainer/Resume" to="." method="_on_resume_pressed"]
 [connection signal="pressed" from="VBoxContainer/Options" to="." method="_on_options_pressed"]
 [connection signal="pressed" from="VBoxContainer/Home" to="." method="_on_home_pressed"]
 [connection signal="pressed" from="VBoxContainer/Quit" to="." method="_on_quit_pressed"]
-[connection signal="pressed" from="VBoxContainer/Resume" to="." method="_on_resume_pressed"]

--- a/Menu/Scripts/menu.gd
+++ b/Menu/Scripts/menu.gd
@@ -1,18 +1,34 @@
 extends Node
 
 
-#used to call
-func _on_play_pressed():
+func play():
 	get_tree().change_scene_to_file("res://Levels/test_level.tscn")
 	print("Loading test_level.tscn")
 
-func _on_options_pressed():
+func open_options():
 	get_tree().change_scene_to_file("res://Menu/Scenes/Options_menu.tscn")
 	print("Loading Options")
 
-func _on_level_select_pressed():
+func open_level_select():
 	get_tree().change_scene_to_file("res://Menu/Scenes/Level_select_menu.tscn")
 	print("Loading Level Select")
+
+
+func _process(_delta_):
+	# Play on spacebar or right click press
+	if Input.is_action_just_pressed("command_guys_stop"):
+		play()
+
+
+# Connected signals for calling functions
+func _on_play_pressed():
+	play()
+
+func _on_options_pressed():
+	open_options()
+
+func _on_level_select_pressed():
+	open_level_select()
 
 func _on_quit_pressed():
 	get_tree().quit()


### PR DESCRIPTION
Main menu refactor allows shortcuts, like SPACE / RClick to Play.
Pause menu no longer draws behind game objects.