### PR TITLE
General cleanup. Debugger now shows zero warnings

### DIFF
--- a/HUD/IngameHUD.gd
+++ b/HUD/IngameHUD.gd
@@ -7,7 +7,6 @@ extends CanvasLayer
 @onready var guy_counter = $GuyCounter
 @onready var guy_sprite = $GuyCounter/GuySprite
 @onready var guys_we_have = $"GuyCounter/Guys we have"
-@onready var slash = $GuyCounter/Slash
 @onready var total_guys = $"GuyCounter/Total guys"
 
 
@@ -25,6 +24,6 @@ func count_guys():
 	guys_we_have.text = str(len(counted_guys))
 
 
-func _process(delta):
+func _process(_delta):
 	wiggle_guy_sprite()
 	count_guys()

--- a/Hazards/GuyEater.gd
+++ b/Hazards/GuyEater.gd
@@ -20,8 +20,7 @@ func _ready():
 	num_of_guys_label.text = str(num_guys_to_eat)
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	# If we've just now eaten enough guys, win!
 	if num_guys_eaten >= num_guys_to_eat and full == false:
 		full = true

--- a/Hazards/red_block.gd
+++ b/Hazards/red_block.gd
@@ -7,6 +7,6 @@ func _ready():
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
+func _process(_delta):
 	pass
 

--- a/Menu/Scenes/Main_menu.tscn
+++ b/Menu/Scenes/Main_menu.tscn
@@ -48,8 +48,6 @@ text = "Level Select"
 layout_mode = 2
 text = "Quit"
 
-[connection signal="gui_input" from="VBoxContainer" to="." method="_on_v_box_container_gui_input"]
-[connection signal="button_up" from="VBoxContainer/Play" to="." method="_on_play_button_up"]
 [connection signal="pressed" from="VBoxContainer/Play" to="." method="_on_play_pressed"]
 [connection signal="pressed" from="VBoxContainer/Options" to="." method="_on_options_pressed"]
 [connection signal="pressed" from="VBoxContainer/Level Select" to="." method="_on_level_select_pressed"]

--- a/Menu/Scenes/Options_menu.tscn
+++ b/Menu/Scenes/Options_menu.tscn
@@ -12,16 +12,19 @@ grow_vertical = 2
 script = ExtResource("1_oxaw2")
 
 [node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 0
 offset_right = 1157.0
 offset_bottom = 653.0
 color = Color(0.0196078, 0.027451, 0.156863, 1)
 
 [node name="ColorRect" type="ColorRect" parent="ColorRect"]
+layout_mode = 0
 offset_right = 1157.0
 offset_bottom = 653.0
 color = Color(0.0196078, 0.027451, 0.156863, 1)
 
 [node name="VBoxContainer" type="VBoxContainer" parent="ColorRect"]
+layout_mode = 0
 offset_left = 414.0
 offset_top = 130.0
 offset_right = 735.0

--- a/Menu/Scripts/Level_manager.gd
+++ b/Menu/Scripts/Level_manager.gd
@@ -3,7 +3,7 @@ extends Node
 @onready var pause_menu = $pausemenu
 var paused = false
 
-func _process(delta):
+func _process(_delta):
 	if Input.is_action_just_pressed("pause"):
 		pauseMenu()
 			

--- a/Menu/Scripts/Options.gd
+++ b/Menu/Scripts/Options.gd
@@ -1,16 +1,6 @@
 extends Node
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
-
-
 func _on_back_pressed():
 	get_tree().change_scene_to_file("res://Menu/Scenes/Main_menu.tscn")
 	print("Loading Menu")

--- a/Scripts/LittleGuys/little_guy_handler.gd
+++ b/Scripts/LittleGuys/little_guy_handler.gd
@@ -22,7 +22,7 @@ func _ready():
 		reconstitue_soft_body()
 	print(Global.DEBUG)
 
-func _process(delta):
+func _process(_delta):
 	if Global.DEBUG:
 		_check_for_debug_inputs()
 		if Global.SOFT_BODY_CONTROL:
@@ -59,7 +59,7 @@ func _on_hazards_body_entered(body):
 	if body.is_in_group("LittleGuy"):
 		body.queue_free()
 
-func _physics_process(delta):
+func _physics_process(_delta):
 	if not Global.SOFT_BODY_CONTROL:
 		return
 	update_spring_forces()

--- a/global.gd
+++ b/global.gd
@@ -2,11 +2,3 @@ extends Node
 
 var DEBUG = true
 var SOFT_BODY_CONTROL = false
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass


### PR DESCRIPTION
Removed unnecessary _ready() and _process() functions.

Added an underscore to _delta in all process functions that don't reference delta again

Debugger now has zero complaints, zero warnings, zero errors.
Please let me know if you find out what's printing "true" to the console on play().